### PR TITLE
Update 2016-06-16-groupby.md

### DIFF
--- a/_posts/2016-06-16-groupby.md
+++ b/_posts/2016-06-16-groupby.md
@@ -65,6 +65,11 @@ print(df)
 However, with many groups, apply operations can be slow:
 
 {% highlight python %}
+import time
+
+n_decimals = 3
+n_iters = 100
+
 n_obs = 10**4
 n_categories = 10**3
 


### PR DESCRIPTION
Add missing import and missing variables to example.

There seems to be another bug that is `off by 1` somewhere on the `Groupby` class but seems it was resolved on the external copy of the class.